### PR TITLE
fix readme incorrect examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ pip install reapy-boost
 One additional step is required to let REAPER know reapy is available. First, open REAPER. Then in a terminal, run:
 
 ```bash
-$ python -c "import reapy_boost; reapy.configure_reaper()"
+$ python -c "import reapy_boost; reapy_boost.configure_reaper()"
 ```
 
 Restart REAPER, and you're all set! You can now import `reapy` from inside or outside REAPER as any standard Python module.
@@ -53,7 +53,7 @@ you can open your usual Python shell and type:
 
 ```python
 >>> import reapy_boost
->>> reapy.print("Hello world!")
+>>> reapy_boost.print("Hello world!")
 ```
 
 ## Usage


### PR DESCRIPTION
Very cool project. The fix in FX functions query makes a lot more sense. 
I notice that configure_reapy() send the api script to Reaper Actions. So if one transitions from Reapy to reapy_boost. It wouldn't work out of the box. In my case, `import reapy_boost` will get stuck because the socket cannot be established. My solution is to removed setting files, in my case (OSX) in `~/Library/Application Support/REAPER/`. And go through the configuration again. 

It is worth to add that to the documentation. 